### PR TITLE
Update resource_head_scrapy.py

### DIFF
--- a/odpw/services/resource_head_scrapy.py
+++ b/odpw/services/resource_head_scrapy.py
@@ -4,7 +4,8 @@ import datetime
 from collections import defaultdict
 
 from scrapy import signals
-from scrapy.xlib.pydispatch import dispatcher
+#from scrapy.xlib.pydispatch import dispatcher
+import pydispatch as dispatcher
 from time import sleep
 
 from scrapy.exceptions import DontCloseSpider


### PR DESCRIPTION
changed the import of dispatcher to avoid the message of the deprecated use of the method